### PR TITLE
Remove trailing colon

### DIFF
--- a/resources/ui/HistoryEntry.js
+++ b/resources/ui/HistoryEntry.js
@@ -49,7 +49,7 @@ define([
                     connectId: [this.delegatedHistoryEntry],
                     label: "<span class=\"delegatedHistoryEntry\">"
                             + "<img class=\"userImage\" src=\"" + this.userImage + "\"></img>"
-                            + "<p>" + this.stateData.modifier + "<br> changed on " + this.formattedDate + ": </p>"
+                            + "<p>" + this.stateData.modifier + "<br> changed on " + this.formattedDate + "</p>"
                             + this.stateDelegate
                         + "</span>",
                     position: ["before", "after"]


### PR DESCRIPTION
Removes the trailing colon from the status history hover presentation.

![status history trailing colon](https://user-images.githubusercontent.com/20296116/51169752-f972c280-18ac-11e9-8798-ee8c3022204e.PNG)
